### PR TITLE
Set vaccine gap chart tooltips to 'index' mode to show all traces at once

### DIFF
--- a/js/vacgraph.js
+++ b/js/vacgraph.js
@@ -176,6 +176,9 @@ function draw(graphConfig) {
             },
             legend: {
                 display: true
+            },
+            tooltips: {
+                mode: 'index'
             }
         }
     });


### PR DESCRIPTION
My apologies if this seems out of the blue. I've been using your Covid19 tracker for a while now and I really like it. I also happen to be the maintainer of Chart.js and noticed that the "Vaccine Gap" visualization could be improved slightly by changing the tooltip to show both traces at once.

![Tooltip](https://user-images.githubusercontent.com/6757853/103592140-397b4780-4ec0-11eb-88e3-437af570d2b3.png)
