### PR TITLE
Vaccine gap chart updates

### DIFF
--- a/js/vacgraph.js
+++ b/js/vacgraph.js
@@ -174,10 +174,29 @@ function draw(graphConfig) {
                     }
                 }],
             },
+            hover: {
+                intersect: false,
+                mode: 'index',
+            },
             legend: {
                 display: true
             },
             tooltips: {
+                callbacks: {
+                    // Show the tooltip rows as nicely formatted numbers
+                    label: function(tooltipItem, data) {
+                        var label = data.datasets[tooltipItem.datasetIndex].label || '';
+
+                        if (label) {
+                            label += ': ';
+                        }
+                        label += tooltipItem.yLabel.toLocaleString();
+                        return label; 
+                    }
+                },
+
+                // Ensure that the user does not have to hover over a point to view the tooltip
+                intersect: false,
                 mode: 'index'
             }
         }


### PR DESCRIPTION
A few suggested updates to the "vaccine gap" chart to improve readability. I'm happy to make similar changes on the other charts if you like the direction this is going.

* Show the tooltip rows as nicely formatted numbers
* Ensure that users do not need to hover over a point to view the tooltip

![vax chart locale formatted](https://user-images.githubusercontent.com/6757853/107597082-98cb2680-6be7-11eb-9b7a-e83d393c8c66.png)
