### PR TITLE
Renamed "vaccinated" headers to "doses administered"

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -48,7 +48,7 @@ $(document).ready(() => {
         $(".summary-header-recoveries > b").text(displayNewCases(data.change_recoveries));
         $(".summary-header-tests > h1").text(data.total_tests + " tests");
         $(".summary-header-tests > b").text(displayNewCases(data.change_tests));
-        $(".summary-header-vaccinations > h1").text(data.total_vaccinations + " vaccinated");
+        $(".summary-header-vaccinations > h1").text(data.total_vaccinations + " doses administered");
         $(".summary-header-vaccinations > b").text(displayNewCases(data.change_vaccinations));
 
         // update province table footer

--- a/js/province.js
+++ b/js/province.js
@@ -115,7 +115,7 @@ $(document).ready(() => {
             if (lastItem.total_vaccinations === null || lastItem.total_vaccinations === undefined)
                 $(".summary-header-vaccinations").closest(".col-md").hide();
             else {
-                $(".summary-header-vaccinations > h1").text(lastItem.total_vaccinations + " vaccinated");
+                $(".summary-header-vaccinations > h1").text(lastItem.total_vaccinations + " doses administered");
                 if (lastItem.change_vaccinations !== null && lastItem.change_vaccinations !== undefined)
                     $(".summary-header-vaccinations > b").text(displayNewCases(lastItem.change_vaccinations));
             }
@@ -181,7 +181,7 @@ $(document).ready(() => {
             $(".summary-header-recoveries > b").text(displayNewCases(province.change_recoveries));
             $(".summary-header-tests > h1").text(province.total_tests + " tests");
             $(".summary-header-tests > b").text(displayNewCases(province.change_tests));
-            $(".summary-header-vaccinations > h1").text(province.total_vaccinations + " vaccinated");
+            $(".summary-header-vaccinations > h1").text(province.total_vaccinations + " doses administered");
             $(".summary-header-vaccinations > b").text(displayNewCases(province.change_vaccinations));
         });
 

--- a/js/vacregmain.js
+++ b/js/vacregmain.js
@@ -151,7 +151,6 @@ $(document).ready(() => {
         // get and update header, and cases by province table footer
         //draw map and cases by province graph and table
 
-
         document.querySelector('title').textContent = `COVID-19 Tracker Canada - ${pText} Vaccination Tracker`;
 
         $.ajax({
@@ -291,7 +290,6 @@ function buildRegionTable(data, regionData) {
         var regName = typeof regProvinceData !== "undefined" ? regProvinceData.engname : "Region " + item.hr_uid;
         var itemTotalVaccinations = (item.total_vaccinations === null || item.total_vaccinations === undefined) ? "No Data" : item.total_vaccinations;
         var itemTotalVaccinated = (item.total_vaccinated === null || item.total_vaccinated === undefined) ? "No Data" : item.total_vaccinated;
-
         // append data to row
         $('#vaccinationsProvinceTable').append(
             "<tr class='provinceRow'>" +

--- a/js/vacregmain.js
+++ b/js/vacregmain.js
@@ -150,7 +150,7 @@ $(document).ready(() => {
         //$(".display-select").hide();
         // get and update header, and cases by province table footer
         //draw map and cases by province graph and table
-        
+
 
         document.querySelector('title').textContent = `COVID-19 Tracker Canada - ${pText} Vaccination Tracker`;
 
@@ -291,7 +291,7 @@ function buildRegionTable(data, regionData) {
         var regName = typeof regProvinceData !== "undefined" ? regProvinceData.engname : "Region " + item.hr_uid;
         var itemTotalVaccinations = (item.total_vaccinations === null || item.total_vaccinations === undefined) ? "No Data" : item.total_vaccinations;
         var itemTotalVaccinated = (item.total_vaccinated === null || item.total_vaccinated === undefined) ? "No Data" : item.total_vaccinated;
-        
+
         // append data to row
         $('#vaccinationsProvinceTable').append(
             "<tr class='provinceRow'>" +


### PR DESCRIPTION
There are a few places where we see "x# vaccinated". 
<img width="234" alt="Screen Shot 2021-04-21 at 9 10 08 AM" src="https://user-images.githubusercontent.com/11506653/115559131-6857d680-a281-11eb-8346-9002d1ca0c8f.png">

However, I don't think this is actually what we want to show and is potentially misleading. Instead, we want to show that this is the total # of doses administered, which is what is already show on the "Vaccination Tracker" page.
I think this small change can make things a lot clearer for users (especially ones who only visit the landing page of the site).
What do you think @noahlittle ?