### PR TITLE
Revert AB population to use original StatsCan data

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -291,7 +291,7 @@ function provinceProperties(code, name) {
             name: "Alberta",
             population : 4444277,
             code: "AB",
-			displayNotes: true
+			displayNotes: false
         },
         "PE": {
             name: "Prince Edward Island",

--- a/js/vacregmain.js
+++ b/js/vacregmain.js
@@ -19,7 +19,7 @@ var adults = 0;
 var adultsFull = 0;
 var populationObj = [{
     "province": "AB",
-    "population": 3806860
+    "population": 3761130
 }, {
     "province": "BC",
     "population": 4577078

--- a/provincevac.html
+++ b/provincevac.html
@@ -25,7 +25,7 @@
 
     <script type="text/javascript" src="js/config.js?v=7.2.4.0"></script>
     <script type="text/javascript" src="js/vaccharts.js?v=7.0.1.0"></script>
-    <script type="text/javascript" src="js/vacregmain.js?v=10.1.2.0"></script>
+    <script type="text/javascript" src="js/vacregmain.js?v=10.1.3.0"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-160029240-1"></script>


### PR DESCRIPTION
AB has decided to return to StatsCan estimates after using "internal estimates"